### PR TITLE
show_logs/vlog/init_socials: handle scandir error case

### DIFF
--- a/src/admin2.c
+++ b/src/admin2.c
@@ -83,10 +83,12 @@ void vlog(player * p, char *str)
   if (!*str || *str == '?')
   {
     dc = scandir("logs", &de, valid_log, alphasort);
-    if (!dc)
+    if (dc <= 0)
     {
       tell_player(p, " There are currently no log files ...\n");
-      if (de)
+      /* On scandir error (-1) `de` is undefined per POSIX; only free
+         when scandir actually succeeded with zero entries. */
+      if (dc == 0 && de)
 	free(de);
       return;
     }
@@ -236,11 +238,14 @@ void show_logs(player * p, char *str)
     compact++;
 
   dc = scandir("logs", &de, valid_log, alphasort);
-  if (!dc)
+  if (dc <= 0)
   {
     if (!compact)
       tell_player(p, " Log directory is empty ...\n");
-    if (de)
+    /* On scandir error (-1) `de` is undefined per POSIX and may be
+       non-NULL stack garbage; only free when scandir actually
+       succeeded with zero entries. */
+    if (dc == 0 && de)
       free(de);
     return;
   }
@@ -3744,10 +3749,12 @@ void vscript(player * p, char *str)
     else
       dc = scandir("logs/scripts", &de, valid_script, alphasort);
 
-    if (!dc)
+    if (dc <= 0)
     {
       tell_player(p, " There are currently no files in there ...\n");
-      if (de)
+      /* On scandir error (-1) `de` is undefined per POSIX; only free
+         when scandir actually succeeded with zero entries. */
+      if (dc == 0 && de)
 	free(de);
       return;
     }

--- a/src/socials.c
+++ b/src/socials.c
@@ -338,9 +338,11 @@ void init_socials(void)
   int dc = 0;
 
   dc = scandir("files/socials", &de, valid_social, alphasort);
-  if (!dc)
+  if (dc <= 0)
   {
-    if (de)
+    /* On scandir error (-1) `de` is undefined per POSIX; only free
+       when scandir actually succeeded with zero entries. */
+    if (dc == 0 && de)
       free(de);
     return;
   }


### PR DESCRIPTION
Minor bootstrapping issue discovered when testing a fresh install on a Docker + Ubuntu setup. 

`scandir()` returns `-1` if there's no target dir and leaves the result pointer undefined. The existing `if (!dc) { ... free(de); }` pattern only handled the _empty-directory_ case. But on a _no target dir_ error case, `de` could hold some stack garbage and then `free()` would segfault. 

Anything calling upon a log file (such as `vlog`) would trigger this condition. I also patched the same pattern in `files/socials` just in case, even though — unlike logs — that one ought to be there on a fresh install.