### PR TITLE
Fix a bug with incorrect mail count on 64-bit systems

### DIFF
--- a/src/mail.c
+++ b/src/mail.c
@@ -778,10 +778,11 @@ void reconfigure_received_list(saved_player * sp)
 {
   int count = 0;
   int *scan;
-  char *oldstack;
+  char *oldstack, *data_start;
   oldstack = stack;
 
   align(stack);
+  data_start = stack;
   scan = sp->mail_received;
   if (!scan)
     return;
@@ -804,7 +805,7 @@ void reconfigure_received_list(saved_player * sp)
     stack += sizeof(int);
     count++;
     sp->mail_received = (int *) MALLOC(count * sizeof(int));
-    memcpy(sp->mail_received, oldstack, count * sizeof(int));
+    memcpy(sp->mail_received, data_start, count * sizeof(int));
   }
   else
     sp->mail_received = 0;


### PR DESCRIPTION
Bug: mail count is corrupted on 64-bit systems.

**Synopsis**
1. `monkey` logs in. Has zero mails.
2. `marmoset` logs in. Sends `monkey` a mail, subject `test`.
3. `monkey` sees:   
   ```
   -=> New mail 'test'
   -=> Sent by marmoset
   -=> Type "mail read 2" to read
   ```
4. `monkey` types `mail read 2` and gets `No such letter '2'`
5. Expected:
   ```
   -=> New mail 'test'
   -=> Sent by marmoset
   -=> Type "mail read 1" to read
   ```

**Explanation**
On 64-bit systems, `reconfigure_received_list` corrupts the `mail_received` array. `align(stack)` can advance the stack pointer past `oldstack` by up to 7 bytes, but filtered entries are written starting at the post-alignment position. The `memcpy` on line 807 copies from `oldstack` (pre-alignment), picking up garbage bytes from the gap instead of the actual data. This causes phantom mail entries, wrong "mail read N" numbers in notifications, and reads past the allocated buffer. 

**Fix** 
Save the post-alignment position in `data_start` and use it as the `memcpy` source. 

**Compatibility** 
Note that on a 32-bit host, there will be no behavioral change because on 32-bit systems `align()` is a no-op for int-aligned pointers. This fix should be compatible with all systems.